### PR TITLE
Cleanup Editor and handle load out of order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build
 lib
 coverage
 yarn.lock
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lib",
     "assets/*.css"
   ],
-  "main": "./lib/index",
+  "main": "./lib/index.js",
   "homepage": "https://github.com/luigiinred/react-ckeditor-wrapper",
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "rc-tools run build",
+    "babel": "babel src -d lib",
     "gh-pages": "rc-tools run gh-pages",
     "start": "rc-tools run server",
     "pub": "rc-tools run pub --babel-runtime",
@@ -46,6 +47,11 @@
     ]
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es2015-ie": "^6.7.0",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "coveralls": "^2.11.15",
     "css-animation": "^1.2.0",
     "enzyme": "^2.6.0",
@@ -54,14 +60,15 @@
     "jest": "^17.0.3",
     "pre-commit": "1.x",
     "rc-tools": "5.x",
-    "react": "15.x",
+    "react": "^15.6.1",
     "react-addons-test-utils": "15.x",
-    "react-dom": "15.x"
+    "react-dom": "^15.6.1"
   },
   "dependencies": {
     "babel-runtime": "6.x",
     "classnames": "2.x",
     "dom-scroll-into-view": "1.x",
+    "happypack": "3.1.0",
     "rc-animate": "2.x",
     "rc-util": "3.x"
   },

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -4,15 +4,14 @@ import ReactDOM from "react-dom";
 class CKEditor extends Component {
   constructor(props) {
     super(props);
+
+    this.changeListener = this.changeListener.bind(this);
+
     this.state = {
       value: props.value,
       config: props.config || {},
       onChange: props.onChange
     };
-  }
-
-  handleChange() {
-    this.state.onChange(this.state.value);
   }
 
   componentDidMount() {
@@ -26,10 +25,9 @@ class CKEditor extends Component {
       this.state.config,
       this.state.value
     );
-    this.instance.on("change", () => {
-      this.state.value = this.instance.getData();
-      this.handleChange();
-    });
+
+    this.instance.on('instanceReady', (e) => { e.editor.setData(this.state.value); });
+    this.instance.on('change', this.changeListener);
   }
 
   componentWillReceiveProps(props) {
@@ -52,6 +50,20 @@ class CKEditor extends Component {
       config: props.config || {},
       onChange: props.onChange
     });
+  }
+
+  componentWillUnmount() {
+    this.instance.removeListener("change", this.changeListener);
+    this.instance.destroy();
+  }
+
+  changeListener() {
+    this.state.value = this.instance.getData();
+    this.handleChange();
+  }
+
+  handleChange() {
+    this.state.onChange(this.state.value);
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import ckeditor from './ckeditor';
 
 export default ckeditor;
+


### PR DESCRIPTION
This does two things:

Listening for instance ready and setting data handles the situation:

1. CKEditor component mounts with a value of ''
2. Value gets updated to something else
3. CKEditor instance is loaded

Removing the listener and destroying the instance on unmount helps with creating and destroying multiple instances between page loads.