### PR TITLE
Use ref

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -21,7 +21,7 @@ class CKEditor extends Component {
     }
 
     this.instance = window.CKEDITOR.appendTo(
-      ReactDOM.findDOMNode(this),
+      this.divRef,
       this.state.config,
       this.state.value
     );
@@ -67,7 +67,7 @@ class CKEditor extends Component {
   }
 
   render() {
-    return <div />;
+    return <div ref={(input) => this.divRef = input}/>;
   }
 }
 


### PR DESCRIPTION
Use a ref attribute instead of using ReactDOM.findDOMNode(this). The latter is causing problems for me when running development with a linked module (yarn link to this package). It should also be slightly better performance on it.